### PR TITLE
Fix code scanning alert no. 8: Cross-site scripting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.apache.commons:commons-text:1.12.0'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/controller/MainController.java
+++ b/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/controller/MainController.java
@@ -11,6 +11,7 @@ import com.datadoghq.workshops.samplevulnerablejavaapp.service.DTestService;
 import com.datadoghq.workshops.samplevulnerablejavaapp.service.FileService;
 import com.datadoghq.workshops.samplevulnerablejavaapp.service.WebsiteTestService;
 import org.slf4j.Logger;
+import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -50,7 +51,8 @@ public class MainController {
   public ResponseEntity<String> testWebsite(@RequestBody WebsiteTestRequest request) {
     log.info("Testing website " + request.url);
     String result = websiteTestService.testWebsite(request);
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    String safeResult = org.apache.commons.text.StringEscapeUtils.escapeHtml4(result);
+    return new ResponseEntity<>(safeResult, HttpStatus.OK);
   }
 
   @RequestMapping(method=RequestMethod.POST, value="/view-file", consumes="application/json")


### PR DESCRIPTION
Fixes [https://github.com/shunmugadigialert/java1/security/code-scanning/8](https://github.com/shunmugadigialert/java1/security/code-scanning/8)

To fix the cross-site scripting vulnerability, we need to ensure that any user-provided data included in the HTTP response is properly sanitized or encoded. In this case, we should HTML-encode the `result` before including it in the response. This can be achieved using a library like Apache Commons Text, which provides utilities for escaping and encoding.

1. Add the necessary import for Apache Commons Text.
2. Use the `StringEscapeUtils.escapeHtml4` method to encode the `result` before including it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
